### PR TITLE
Added findDOMNode method. Plus some cleanup and minor version bump to align with React

### DIFF
--- a/__tests__/react-testutils-extended.tests.js
+++ b/__tests__/react-testutils-extended.tests.js
@@ -78,6 +78,19 @@ describe("react-testutils-additions tests", function(){
         });
     });
 
+    it("it should be able to find a dom node", function(){
+        var Component = React.createClass({
+            render: function(){ return (<div className="myclass"></div>); }
+        });
+
+        var RenderedComponent = TestUtils.renderIntoDocument(<Component />);
+
+        var result = TestUtils.findDOMNode(RenderedComponent);
+
+        expect(result).toBeDefined();
+        expect(result.getAttribute("class")).toBe("myclass");
+    });
+
     it("it should be able to find components with a class selector", function(){
         var Component = React.createClass({
             render: function(){ return (<div className="myclass"></div>); }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -12,13 +12,12 @@ gulp.task('jshint', function () {
 
 gulp.task('watches', function(){
     gulp.watch([ 
-		basePath + '*.js', 
-		basePath + '__tests__/*.js'
-	], ['jshint', 'tests']);
+        basePath + '*.js', 
+        basePath + '__tests__/*.js'
+    ], ['jshint', 'tests']);
 });
 
 gulp.task('tests', function () {
-    
     return gulp.src(['./fake/*.js'])
         .pipe(karma({
             configFile: 'karma.conf.js',

--- a/index.js
+++ b/index.js
@@ -6,6 +6,10 @@ var sizzle = require("sizzle");
 var objectAssign = require('object-assign');
 var testContainerId = "react-test-additions-testcontainer";
 
+RTA.findDOMNode = function(root){
+    return ReactDOM.findDOMNode(root);
+};
+
 RTA.find = function(root, selector){
     var domInstance = ReactDOM.findDOMNode(root);
     // react always renders the root component in a parent DIV, 
@@ -24,7 +28,7 @@ RTA.findOne = function(root, selector){
     }
 
     if(result.length){
-        return	result[0];
+        return result[0];
     }
 
     return result;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-testutils-additions",
-  "version": "15.0.1",
+  "version": "15.1.0",
   "description": "A module that will extend the default react testutils with extra helpers that will make life easier when testing your react components.",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-testutils-additions",
-  "version": "15.0.0",
+  "version": "15.0.1",
   "description": "A module that will extend the default react testutils with extra helpers that will make life easier when testing your react components.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Rationale:
- Since the findDOMNode method was moved to ReactDOM, you need to have a dependency on ReactDOM in your tests if you want to use the findDOMNode. By adding findDOMNode to RTA, we eliminate this dependency since we already depend on ReactDOM in RTA - this is just for convenience.

See the corresponding test as an example.
