### PR TITLE
Deprecate react-addons-test-utils

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 var React = require('react');
-var ReactTestUtils = require("react-addons-test-utils");
+var ReactTestUtils = require("react-dom/test-utils");
 var ReactDOM = require('react-dom');
 var RTA = ReactTestUtils;
 var sizzle = require("sizzle");

--- a/package.json
+++ b/package.json
@@ -32,14 +32,12 @@
     "karma-jasmine": "^0.2.2",
     "karma-phantomjs-launcher": "~0.1.2",
     "react": "^15.0",
-    "react-addons-test-utils": "^15.0",
     "react-dom": "^15.0",
     "reactify": "^1.1.0"
   },
   "peerDependencies": {
     "react": "15.x",
-    "react-dom": "15.x",
-    "react-addons-test-utils": "15.x"
+    "react-dom": "15.x"
   },
   "dependencies": {
     "object-assign": "~3.0.0",


### PR DESCRIPTION
As of version `15.5.0`, `react-addons-test-utils` has been deprecated and moved to `react-dom/test-utils`.

(https://www.npmjs.com/package/react-addons-test-utils)

Changes
---------
Updates the references to `react-dom/test-utils` and removes the `react-addons-test-utils` dependencies.

Testing
--------
Ran the test suite locally, looked kosher!