### PR TITLE
Groundwork for migrating to React 15.6

### DIFF
--- a/__tests__/react-testutils-extended.tests.js
+++ b/__tests__/react-testutils-extended.tests.js
@@ -1,6 +1,7 @@
 var ReactDOM = require('react-dom');
 var React = require('react');
 var TestUtils = require('../index.js');
+var createReactClass = require('create-react-class');
 
 describe("react-testutils-additions tests", function(){
 
@@ -25,7 +26,7 @@ describe("react-testutils-additions tests", function(){
         it("it should unmount a component when calling the unmountFromDocument func", function(){
             var wasUnmounted = false;
 
-            var Component = React.createClass({
+            var Component = createReactClass({
                 componentWillUnmount: function(){ wasUnmounted = true; },
                 render: function(){ return (<div></div>); }
             });
@@ -40,7 +41,7 @@ describe("react-testutils-additions tests", function(){
     describe("scry and find helpers", function(){
 
         it("it should be able to find a component by its id", function(){
-            var Component = React.createClass({
+            var Component = createReactClass({
                 render: function(){ return (<div id="findme"></div>); }
             });
 
@@ -52,7 +53,7 @@ describe("react-testutils-additions tests", function(){
         });
 
         it("it should be able to scry for components by their attributes values", function(){
-            var Component = React.createClass({
+            var Component = createReactClass({
                 render: function(){ return (<div role="somevalue"></div>); }
             });
 
@@ -65,7 +66,7 @@ describe("react-testutils-additions tests", function(){
         });
 
         it("it should be able to find a component by its attribute value", function(){
-            var Component = React.createClass({
+            var Component = createReactClass({
                 render: function(){ return (<div role="somevalue"></div>); }
             });
 
@@ -79,7 +80,7 @@ describe("react-testutils-additions tests", function(){
     });
 
     it("it should be able to find a dom node", function(){
-        var Component = React.createClass({
+        var Component = createReactClass({
             render: function(){ return (<div className="myclass"></div>); }
         });
 
@@ -92,7 +93,7 @@ describe("react-testutils-additions tests", function(){
     });
 
     it("it should be able to find components with a class selector", function(){
-        var Component = React.createClass({
+        var Component = createReactClass({
             render: function(){ return (<div className="myclass"></div>); }
         });
 
@@ -105,7 +106,7 @@ describe("react-testutils-additions tests", function(){
     });
 
     it("it should be able to find a component with an id selector", function(){
-        var Component = React.createClass({
+        var Component = createReactClass({
             render: function(){ return (<div id="myid"></div>); }
         });
 
@@ -116,7 +117,7 @@ describe("react-testutils-additions tests", function(){
     });
 
     it("it should be able to find components with a tag selector", function(){
-        var Component = React.createClass({
+        var Component = createReactClass({
             render: function(){ return (<div><span>1</span><span>2</span></div>); }
         });
 
@@ -131,7 +132,7 @@ describe("react-testutils-additions tests", function(){
 
 
     it("it should be able to find nested components with a selector", function(){
-        var Component = React.createClass({
+        var Component = createReactClass({
             render: function(){
                 return (
                     <div id="myid">
@@ -156,7 +157,7 @@ describe("react-testutils-additions tests", function(){
     });
 
     it("it should be able to find multiple nested components with a selector", function(){
-        var Component = React.createClass({
+        var Component = createReactClass({
             render: function(){
                 return (
                     <div id="myid">
@@ -180,7 +181,7 @@ describe("react-testutils-additions tests", function(){
     });
 
     it("it should return an empty array when a component by tag could not be found", function(){
-        var Component = React.createClass({
+        var Component = createReactClass({
             render: function(){
                 return (
                     <div id="myid">
@@ -197,7 +198,7 @@ describe("react-testutils-additions tests", function(){
     });
 
     it("it should be able to findone when there is only one", function(){
-        var Component = React.createClass({
+        var Component = createReactClass({
             render: function(){ return (<div className="myclass"><div id="myid"></div></div>); }
         });
 
@@ -211,7 +212,7 @@ describe("react-testutils-additions tests", function(){
     });
 
     it("it should throw when findOne finds more than one", function(){
-        var Component = React.createClass({
+        var Component = createReactClass({
             render: function(){ return (<div>
                                             <span className="myclass"></span>
                                             <span className="myclass"></span>
@@ -228,7 +229,7 @@ describe("react-testutils-additions tests", function(){
     });
 
     it("it should throw when findOne does not find anything", function(){
-        var Component = React.createClass({
+        var Component = createReactClass({
             render: function(){ return (<div></div>); }
         });
 
@@ -242,7 +243,7 @@ describe("react-testutils-additions tests", function(){
     });
 
     it("should be able to find components with multiple selectors on the same element", function() {
-        var Component = React.createClass({
+        var Component = createReactClass({
             render: function(){
                 return (
                     <div id="myid">
@@ -271,7 +272,7 @@ describe("react-testutils-additions tests", function(){
         var propUpdated = jasmine.createSpy(), updatedProps = {};
 
         it("it should be able to update the props by using the test container wrapper", function(){
-            var Component = React.createClass({
+            var Component = createReactClass({
                 getDefaultProps: function () {
                     return { foo: "foo", bar: "bar" }
                 },
@@ -283,7 +284,7 @@ describe("react-testutils-additions tests", function(){
             });
 
             var WrappedComponent = TestUtils.renderIntoTestContainer(<Component />);
-            
+
             WrappedComponent.updateProps({ foo: "updatedfoo" });
 
             expect(propUpdated).toHaveBeenCalled();

--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@ var RTA = ReactTestUtils;
 var sizzle = require("sizzle");
 var objectAssign = require('object-assign');
 var testContainerId = "react-test-additions-testcontainer";
+var createReactClass = require('create-react-class');
 
 RTA.findDOMNode = function(root){
     return ReactDOM.findDOMNode(root);
@@ -12,7 +13,7 @@ RTA.findDOMNode = function(root){
 
 RTA.find = function(root, selector){
     var domInstance = ReactDOM.findDOMNode(root);
-    // react always renders the root component in a parent DIV, 
+    // react always renders the root component in a parent DIV,
     // so using the parentNode should not be a problem.
     var result = sizzle(selector, domInstance.parentNode);
     return result;
@@ -45,17 +46,17 @@ RTA.findRenderedDOMComponentWithAttributeValue = function(root, propName, propVa
     if (all.length !== 1) {
         throw new Error('Did not find exactly one match for attribute ' + propName + ' with value ' + propValue);
     }
-    
+
     return all[0];
 };
 
 RTA.findRenderedDOMComponentWithId = function(root, propValue) {
     var all = this.scryRenderedDOMComponentsWithAttributeValue(root, "id", propValue);
-    
+
     if (all.length !== 1) {
         throw new Error('Did not find exactly one match for id:' + propValue);
     }
-    
+
     return all[0];
 };
 
@@ -64,7 +65,7 @@ RTA.unmountFromDocument = function(root) {
 };
 
 RTA.renderIntoTestContainer = function(instance) {
-    var TestContainer = React.createClass({
+    var TestContainer = createReactClass({
         updateProps: function(props) {
             this.copiedProps = objectAssign(this.copiedProps, props);
             this.forceUpdate();
@@ -81,10 +82,10 @@ RTA.renderIntoTestContainer = function(instance) {
         },
         render: function() {
             var clonedElement = React.cloneElement(instance, this.copiedProps);
-            return React.createElement('div', { id: testContainerId }, clonedElement); 
+            return React.createElement('div', { id: testContainerId }, clonedElement);
         }
     });
-    
+
     return ReactTestUtils.renderIntoDocument(React.createElement(TestContainer));
 };
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-testutils-additions",
-  "version": "15.2.0",
+  "version": "15.3.0",
   "description": "A module that will extend the default react testutils with extra helpers that will make life easier when testing your react components.",
   "main": "index.js",
   "scripts": {
@@ -21,17 +21,18 @@
   },
   "devDependencies": {
     "browserify": "14.3.0",
+    "create-react-class": "^15.6.2",
     "es5-shim": "4.5.9",
+    "jasmine-core": "2.5.2",
     "karma": "1.6.0",
     "karma-browserify": "5.1.1",
-    "watchify": "3.9.0",
     "karma-chrome-launcher": "2.0.0",
-    "jasmine-core": "2.5.2",
     "karma-jasmine": "1.1.0",
     "karma-phantomjs-launcher": "1.0.4",
     "react": "^15.5",
     "react-dom": "^15.5",
-    "reactify": "1.1.1"
+    "reactify": "1.1.1",
+    "watchify": "3.9.0"
   },
   "peerDependencies": {
     "react": ">= 15.5.0 < 16",


### PR DESCRIPTION
React.createClass is marked as obsolete and will be removed in React v16.0
This  PR will get rid of the warning and makes it easier to migrate to v16